### PR TITLE
Enable execute permission of run.sh upon container startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,6 @@ RUN pip install --no-cache-dir --upgrade -r requirements.txt
 
 COPY . /app
 
+RUN chmod +x run.sh
+
 CMD ["yacron", "-c", "crontab.yml"]


### PR DESCRIPTION
Issue: leetcode-bot stops pushing exercises everynow and then

Diagnosis: Everytime the flyio server restarts, the `run.sh` script, which pushes exercises to zulip, loses execute permissions. 

Fix: Add `chmod +x` in Dockerfile to retain execute permissions on server restarts